### PR TITLE
Reworked non-iid distribution, added CLI argument to test

### DIFF
--- a/federatedrc/client.py
+++ b/federatedrc/client.py
@@ -18,7 +18,6 @@ from federatedrc.client_utils import (
     plot_results,
 )
 from federatedrc import network
-from federatedrc import data_distribution
 
 
 class ClientConfig(NamedTuple):
@@ -43,7 +42,6 @@ class FederatedClient:
         interactive=False,
         shared_test=None,
         verbose=False,
-        distribution=None,
     ):
         self._train = train
         self._test = test
@@ -51,7 +49,6 @@ class FederatedClient:
         self._configpath = configpath
         self._interactive = interactive
         self._verbose = verbose
-        self._distribution = distribution
 
         self._model = None
         self._loss = None
@@ -63,14 +60,6 @@ class FederatedClient:
             self._shell = threading.Thread(target=client_shell, args=(self,))
             self._shell.setDaemon(True)
             self._shell.start()
-        
-        if self._distribution:
-            dataDistTrain = data_distribution.DataDistributor(self._train, 10)
-            dataDistTest = data_distribution.DataDistributor(self._train, 10)
-            ## Only take 4/5 of the data. When redistributing, cannot get the exact same number of data points back
-            ## must be smaller since we are sampling from it
-            self._train = dataDistTrain.distribute_data(self._distribution, len(self._train) * 4 / 5)
-            self._test = dataDistTest.distribute_data(self._distribution, len(self._test) * 4 / 5)
         
         # Suppress error messages from quitting
         def keyboard_interrupt_handler(signal, frame):

--- a/federatedrc/data_distribution.py
+++ b/federatedrc/data_distribution.py
@@ -1,16 +1,12 @@
+from collections import defaultdict
 import random
 
 ## Assumes data is not a tensor
 class DataDistributor:
     def __init__(self, data, num_classes):
         self.classes = num_classes
-        self.buckets = []
-        self.init_buckets()
+        self.buckets = defaultdict(list)
         self.assign_data(data)
-
-    def init_buckets(self):
-        for _ in range(self.classes):
-            self.buckets.append([])
 
     def assign_data(self, data):
         for elem in data:

--- a/federatedrc/data_distribution.py
+++ b/federatedrc/data_distribution.py
@@ -1,13 +1,10 @@
-import torch.distributions as distributions
-import torch
-import math
+import random
 
 ## Assumes data is not a tensor
 class DataDistributor:
     def __init__(self, data, num_classes):
         self.classes = num_classes
         self.buckets = []
-
         self.init_buckets()
         self.assign_data(data)
 
@@ -19,39 +16,14 @@ class DataDistributor:
         for elem in data:
             self.buckets[elem[1]].append(elem)
 
-    def parse_distribution(self, dist_name, desired_class):  
-        if dist_name == "Normal":
-            return distributions.Normal(desired_class, math.sqrt(self.classes))
+    def distribute_data(self, dist, num_elements):
+        if sum(dist) > 1:
+            dist = [float(a) / float(sum(dist)) for a in dist]
 
-        else:
-            if desired_class == 1 or desired_class == 0:
-                rate = .9
-            else:
-                rate = 1 / desired_class
-
-            return distributions.Exponential(rate)
-
-    def distribute(self, dist, num_elements):
         data = []
-
-        for _ in range(num_elements):
-            label = self.classes
-
-            while(label >= self.classes):
-                label = int(dist.sample().tolist())
-
-                if label < 0:
-                    label *= -1
-
-            uniformDist = distributions.Uniform(0, len(self.buckets[label]) - 1)
-            index = int(uniformDist.sample().tolist())
-
-            data.append(self.buckets[label][index])
-            ##print("Label: ", label)
-            ##print("Index: ", index)
-
+        for i in range(self.classes):
+            num_unique = int(dist[i] * num_elements)
+            data.extend(random.sample(self.buckets[i], num_unique))
+            
+        random.shuffle(data)
         return data
-
-    def change_distribution(self, dist_name, desired_class, num_elements):
-        dist = self.parse_distribution(dist_name, desired_class)
-        return self.distribute(dist, num_elements)

--- a/tests/test_mnist_fed_avg_client.py
+++ b/tests/test_mnist_fed_avg_client.py
@@ -15,12 +15,18 @@ def fetch_mnist_data():
 
 def launch_federated_client(args):
     train, test = fetch_mnist_data()
+    if args.distribution:
+        int_distribution = [int(i) for i in args.distribution]
+    else:
+        int_distribution = None
+        
     fc = FederatedClient(
         train,
         test,
         configpath = args.configpath[0],
         interactive = args.interactive,
-        verbose = args.verbose
+        verbose = args.verbose,
+        distribution = int_distribution
     )
     fc.train_fed_avg()
 
@@ -39,6 +45,10 @@ if __name__ == '__main__':
     parser.add_argument(
         '--verbose', action='store_true', dest='verbose',
         help='flag to provide extra debugging outputs'
+    )
+    parser.add_argument(
+        '--distribution', nargs=10, dest='distribution', default= None,
+        help='weights for each of 10 handwritten mnist digits'
     )
     args = parser.parse_args()
     launch_federated_client(args)

--- a/tests/test_mnist_fed_avg_client.py
+++ b/tests/test_mnist_fed_avg_client.py
@@ -3,30 +3,34 @@ import torch
 from torchvision import transforms, datasets
 
 from federatedrc.client import FederatedClient
+from federatedrc.data_distribution import DataDistributor
+
 
 def fetch_mnist_data():
     tensor_transform = transforms.Compose([transforms.ToTensor()])
     full_train = datasets.MNIST(root='./data', train=True, download=True, transform=tensor_transform)
     full_test = datasets.MNIST(root='./data', train=False, download=True, transform=tensor_transform)
-
-    train = torch.utils.data.Subset(full_train, range(0, 2000))
-    test = torch.utils.data.Subset(full_test, range(2000, 2500)) 
-    return train, test
+    return full_train, full_test
 
 def launch_federated_client(args):
-    train, test = fetch_mnist_data()
+    full_train, full_test = fetch_mnist_data()
     if args.distribution:
         int_distribution = [int(i) for i in args.distribution]
+    # distribute data uniformly if unspecified
     else:
-        int_distribution = None
-        
+        int_distribution = [1 for _ in range(10)]
+
+    train_distributor = DataDistributor(full_train, 10)
+    test_distributor = DataDistributor(full_test, 10)
+    train = train_distributor.distribute_data(int_distribution, args.n_train)
+    test = test_distributor.distribute_data(int_distribution, args.n_test)
+
     fc = FederatedClient(
         train,
         test,
         configpath = args.configpath[0],
         interactive = args.interactive,
         verbose = args.verbose,
-        distribution = int_distribution
     )
     fc.train_fed_avg()
 
@@ -48,7 +52,15 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--distribution', nargs=10, dest='distribution', default= None,
-        help='weights for each of 10 handwritten mnist digits'
+        metavar='#', help='weights for each of 10 handwritten mnist digits'
+    )
+    parser.add_argument(
+        '--n_train', nargs=1, dest='n_train', default=3000,
+        help='number of images to use in training'
+    )
+    parser.add_argument(
+        '--n_test', nargs=1, dest='n_test', default=800,
+        help='number of images to use for testing'
     )
     args = parser.parse_args()
     launch_federated_client(args)

--- a/tests/test_mnist_nonIID_distribution.py
+++ b/tests/test_mnist_nonIID_distribution.py
@@ -16,10 +16,8 @@ if __name__ == '__main__':
     dataDist = data_distribution.DataDistributor(train, 10)
 
     num_samples = 500
-    skewed_class = 7
+    dist = [4, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    data = dataDist.distribute_data(dist, num_samples)
 
-    geom_data = dataDist.change_distribution("Geometric", skewed_class, num_samples)
-    norm_data = dataDist.change_distribution("Normal", skewed_class, num_samples)
-
-    plt.hist([i[1] for i in norm_data])
+    plt.hist([i[1] for i in data])
     plt.show()

--- a/tests/test_mnist_nonIID_distribution.py
+++ b/tests/test_mnist_nonIID_distribution.py
@@ -6,18 +6,17 @@ import matplotlib.pyplot as plt
 def fetch_mnist_data():
     full_train = datasets.MNIST(root='./data', train=True, download=True)
     full_test = datasets.MNIST(root='./data', train=False, download=True)
-
-    train = torch.utils.data.Subset(full_train, range(0, 2000))
-    test = torch.utils.data.Subset(full_test, range(2000, 2500)) 
-    return train, test
+    return full_train, full_test
 
 if __name__ == '__main__':
-    train, test = fetch_mnist_data()
-    dataDist = data_distribution.DataDistributor(train, 10)
+    full_train, full_test = fetch_mnist_data()
+    dataDist = data_distribution.DataDistributor(full_train, 10)
 
     num_samples = 500
-    dist = [4, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    dist = [4, 5, 6, 2, 1, 1, 1, 1, 1, 1]
     data = dataDist.distribute_data(dist, num_samples)
 
     plt.hist([i[1] for i in data])
+    plt.xlabel('Digit')
+    plt.ylabel('Frequency')
     plt.show()


### PR DESCRIPTION
Reworked non-iid distribution capability to take an array of values representing the probability of each character being chosen. 

Example of testing:
python3 -m tests.test_mnist_fed_avg_client --configpath tests/config/mnist_client_config.py --distribution 1 1 1 1 1 1 1 1 1 1

This will cause the client to run with each digit being equally as likely. 